### PR TITLE
refactor: padronização de usuario_id e migrations automáticas

### DIFF
--- a/back-end/src/controllers/MetaController.js
+++ b/back-end/src/controllers/MetaController.js
@@ -9,13 +9,15 @@ module.exports = {
        */
     async create(req, res) {
         try {
-            const { descricao, link, dataConcDesejada } = req.body;
+            const { usuario_id, titulo, descricao, dataConclusaoDesejada, status } = req.body;
             const meta = await Meta.create({
+                usuario_id: usuario_id,
+                titulo: titulo || null,
                 descricao: descricao,
-                link: link,
-                dataConcDesejada: dataConcDesejada,
-                dataConcluida: null,
-                created_at: new Date()
+                dataConclusaoDesejada: dataConclusaoDesejada || null,
+                status: status || 'pendente',
+                criado_em: new Date(),
+                atualizado_em: new Date()
             });
             return res.status(201).json(meta);
         } catch (error) {
@@ -68,24 +70,27 @@ module.exports = {
 
     async update(req, res) {
         try {
-            const { user_id, descricao, link, dataConcDesejada, status } = req.body;
+            const { id } = req.params;
+            const { usuario_id, titulo, descricao, dataConclusaoDesejada, status } = req.body;
+            
+            const updateData = {};
+            if (usuario_id !== undefined) updateData.usuario_id = usuario_id;
+            if (titulo !== undefined) updateData.titulo = titulo;
+            if (descricao !== undefined) updateData.descricao = descricao;
+            if (dataConclusaoDesejada !== undefined) updateData.dataConclusaoDesejada = dataConclusaoDesejada;
+            if (status !== undefined) updateData.status = status;
+            updateData.atualizado_em = new Date();
+
             const meta = await Meta.update(
-                {
-                    descricao: descricao,
-                    link: link,
-                    dataConcDesejada: dataConcDesejada,
-                    status: status
-                },
+                updateData,
                 {
                     where: {
-                        user_id: user_id
+                        id: id
                     }
                 }
             );
-            return res.status(201).json(meta);
-        }
-
-        catch (error) {
+            return res.status(200).json(meta);
+        } catch (error) {
             console.error('Erro ao atualizar meta: ', error);
             return res.status(500).json({ error: 'Erro interno do servidor' });
         }
@@ -97,19 +102,20 @@ module.exports = {
        */
     async markAsComplete(req, res) {
         try {
-            const { user_id } = req.body;
+            const { id } = req.params;
             const meta = await Meta.update(
-                { dataConcluida: Date.now(), status: 'concluída' },
+                { 
+                    status: 'concluida',
+                    atualizado_em: new Date()
+                },
                 {
                     where: {
-                        user_id: user_id
+                        id: id
                     }
                 }
             );
-            return res.status(201).json(meta);
-        }
-
-        catch (error) {
+            return res.status(200).json(meta);
+        } catch (error) {
             console.error('Erro ao atualizar meta: ', error);
             return res.status(500).json({ error: 'Erro interno do servidor' });
         }
@@ -121,10 +127,10 @@ module.exports = {
    */
     async delete(req, res) {
         try {
-            const { user_id } = req.body;
+            const { id } = req.params;
             await Meta.destroy({
                 where: {
-                    user_id: user_id
+                    id: id
                 }
             });
             return res.status(204).send();

--- a/back-end/src/migrations/rename-meta-userid-to-usuario-id.js
+++ b/back-end/src/migrations/rename-meta-userid-to-usuario-id.js
@@ -1,0 +1,50 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    try {
+      const [results] = await queryInterface.sequelize.query(`
+        SELECT COLUMN_NAME 
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE TABLE_SCHEMA = DATABASE() 
+        AND TABLE_NAME = 'Meta' 
+        AND COLUMN_NAME = 'userId'
+      `);
+
+      if (results.length > 0) {
+        await queryInterface.sequelize.query(`
+          ALTER TABLE Meta CHANGE userId usuario_id INT
+        `);
+        console.log('✅ Coluna userId renomeada para usuario_id na tabela Meta');
+      } else {
+        console.log('ℹ️  Coluna userId não encontrada. Pode já ter sido renomeada ou não existir.');
+      }
+    } catch (error) {
+      if (error.message.includes('Unknown column')) {
+        console.log('ℹ️  Coluna userId não encontrada. Pode já ter sido renomeada.');
+      } else {
+        throw error;
+      }
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    try {
+      const [results] = await queryInterface.sequelize.query(`
+        SELECT COLUMN_NAME 
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE TABLE_SCHEMA = DATABASE() 
+        AND TABLE_NAME = 'Meta' 
+        AND COLUMN_NAME = 'usuario_id'
+      `);
+
+      if (results.length > 0) {
+        await queryInterface.sequelize.query(`
+          ALTER TABLE Meta CHANGE usuario_id userId INT
+        `);
+        console.log('✅ Coluna usuario_id renomeada de volta para userId na tabela Meta');
+      }
+    } catch (error) {
+      console.log('⚠️  Erro ao reverter migration:', error.message);
+    }
+  },
+};
+

--- a/back-end/src/models/Meta.js
+++ b/back-end/src/models/Meta.js
@@ -21,7 +21,11 @@ module.exports = (sequelize, DataTypes) => {
     },
     usuario_id: {
       type: DataTypes.INTEGER,
-      foreignKey: true,
+      allowNull: true,
+    },
+    titulo: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     descricao: {
       type: DataTypes.STRING,
@@ -31,19 +35,25 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.ENUM('pendente', 'concluida', 'cancelada'),
       allowNull: false,
     },
-    dataConcDesejada: {
+    dataConclusaoDesejada: {
       type: DataTypes.DATE,
+      field: 'dataConclusaoDesejada', // Nome da coluna no banco
     },
-    dataConcluida: {
+    criado_em: {
       type: DataTypes.DATE,
-    },
-    created_at: {
-      type: DataTypes.DATE,
+      field: 'criado_em', // Nome da coluna no banco
       defaultValue: DataTypes.NOW,
+    },
+    atualizado_em: {
+      type: DataTypes.DATE,
+      field: 'atualizado_em', // Nome da coluna no banco
     },
   }, {
     sequelize,
     modelName: 'Meta',
+    tableName: 'Meta',
+    timestamps: false, // Desabilitado porque usamos criado_em e atualizado_em manualmente
+    underscored: false,
   });
   return Meta;
 };

--- a/front-end/src/pages/Dashboard.jsx
+++ b/front-end/src/pages/Dashboard.jsx
@@ -78,8 +78,8 @@ export default function Dashboard() {
               meta.status !== "concluída"
           )
           .sort((a, b) => {
-            const dataA = new Date(a.dataConcDesejada || 0);
-            const dataB = new Date(b.dataConcDesejada || 0);
+            const dataA = new Date(a.dataConclusaoDesejada || a.dataConcDesejada || 0);
+            const dataB = new Date(b.dataConclusaoDesejada || b.dataConcDesejada || 0);
             return dataA - dataB;
           });
 
@@ -320,9 +320,9 @@ export default function Dashboard() {
                       ✓ Concluir
                     </button>
                   </div>
-                  {meta.dataConcDesejada && (
+                  {(meta.dataConclusaoDesejada || meta.dataConcDesejada) && (
                     <span className="text-sm text-textoEscuro/60">
-                    📅 Meta: {formatarData(meta.dataConcDesejada)}
+                    📅 Meta: {formatarData(meta.dataConclusaoDesejada || meta.dataConcDesejada)}
                   </span>
                   )}
                 </div>


### PR DESCRIPTION
- Padroniza uso de 'usuario_id' em toda aplicação (substitui 'userId' na Meta)
- Atualiza modelo Meta, MetaController e Dashboard para usar 'usuario_id'
- Cria migration para renomear coluna 'userId' para 'usuario_id' na tabela Meta
- Implementa execução automática de migrations no server.js
- Garante que todos do time recebam atualizações do banco automaticamente
- Adiciona tabela SequelizeMeta para rastrear migrations executadas